### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An official implementation of an [MCP (Model Context Protocol)](https://modelcon
 
 [A few more words about why it was built and some thoughts about the future of MCP](https://screenshotone.com/blog/mcp-server/).
 
+<a href="https://glama.ai/mcp/servers/nq85q0596a">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/nq85q0596a/badge" alt="ScreenshotOne Server MCP server" />
+</a>
+
 ## Tools
 
 -   `render-website-screenshot`: Render a screenshot of a website and returns it as an image.


### PR DESCRIPTION
This PR adds a badge for the [ScreenshotOne MCP Server](https://glama.ai/mcp/servers/nq85q0596a) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/nq85q0596a">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/nq85q0596a/badge" alt="ScreenshotOne Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.